### PR TITLE
Created custom Play runner starter for New Relic

### DIFF
--- a/nr/src/main/scala/sbt/nr/SbtNrPlugin.scala
+++ b/nr/src/main/scala/sbt/nr/SbtNrPlugin.scala
@@ -9,27 +9,14 @@ import java.io.File
 object SbtNrPlugin extends AutoPlugin {
 
   lazy val defaultNrSettings: Seq[Def.Setting[_]] = Seq(
-    inTask(run)(Seq(runner <<= nrRunner)).head,
-
-    mainClass in run <<= mainClass in run in Compile,
-
-    unmanagedClasspath <<= unmanagedClasspath in Runtime,
-    managedClasspath <<= managedClasspath in Runtime,
-    internalDependencyClasspath <<= internalDependencyClasspath in Runtime,
-    externalDependencyClasspath <<= Classpaths.concat(unmanagedClasspath, managedClasspath),
-    dependencyClasspath <<= Classpaths.concat(internalDependencyClasspath, externalDependencyClasspath),
-    exportedProducts <<= exportedProducts in Runtime,
-    fullClasspath <<= Classpaths.concatDistinct(exportedProducts, dependencyClasspath),
-
-    UIKeys.backgroundRunMain <<= SbtBackgroundRunPlugin.backgroundRunMainTask(fullClasspath, runner in run),
-    UIKeys.backgroundRun <<= SbtBackgroundRunPlugin.backgroundRunTask(fullClasspath, mainClass in run, runner in run)
+    inTask(run)(Seq(runner <<= nrRunner)).head
   )
 
   object autoImport {
     val NewRelic = config("newrelic").extend(Compile)
-    val newRelicAgentJar = SettingKey[String]("NewRelic agent jar file.")
-    val newRelicConfigFile = SettingKey[String]("NewRelic configuration file, see https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file for documentation.")
-    val newRelicEnvironment = SettingKey[String]("NewRelic run environment, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/connecting-hosts-your-account#environments for documentation.")
+    val newRelicAgentJar = taskKey[String]("NewRelic agent jar file.")
+    val newRelicConfigFile = taskKey[String]("NewRelic configuration file, see https://docs.newrelic.com/docs/agents/java-agent/configuration/java-agent-configuration-config-file for documentation.")
+    val newRelicEnvironment = taskKey[String]("NewRelic run environment, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/connecting-hosts-your-account#environments for documentation.")
   }
 
   import autoImport._
@@ -42,23 +29,23 @@ object SbtNrPlugin extends AutoPlugin {
     if (jarFilePath == "") {
       errorMessages += "Set 'newRelicAgentJar in NewRelic := \"<filename>\"' in your build to the location of the New Relic agent jar file."
     } else if (!exists(jarFilePath)) {
-      errorMessages += "The specified file '" + jarFilePath + 
+      errorMessages += "The specified file '" + jarFilePath +
         "' does not exist. Please make sure the location is correctly set with 'newRelicAgentJar in NewRelic := \"<filename>\"'"
     }
 
     if (configFilePath == "") {
       errorMessages += "Create a configuration file for New Relic and set 'newRelicConfigFile := \"<filename>\"' in your build."
     } else if (!exists(configFilePath)){
-      errorMessages += "The specified file '" + configFilePath + 
-        "' does not exist. Please make sure the location is correctly set with 'newRelicConfigFile in NewRelic := \"<filename>\"'" 
+      errorMessages += "The specified file '" + configFilePath +
+        "' does not exist. Please make sure the location is correctly set with 'newRelicConfigFile in NewRelic := \"<filename>\"'"
     }
-  
+
     if (errorMessages.size > 0) {
       throw new RuntimeException(errorMessages.mkString("\n"))
-    } 
+    }
   }
 
-  def nrRunner: Initialize[Task[ScalaRun]] = Def.task {        
+  def nrRunner: Initialize[Task[ScalaRun]] = Def.task {
     verifySettings(newRelicAgentJar.value, newRelicConfigFile.value)
 
     val nrJavaOptions: Seq[String] = Seq(
@@ -68,7 +55,7 @@ object SbtNrPlugin extends AutoPlugin {
       "-Dnewrelic.enable.java.8")
 
     val forkConfig = ForkOptions(javaHome.value, outputStrategy.value, Seq.empty, Some(baseDirectory.value), nrJavaOptions, connectInput.value)
-        
+
     if (fork.value) new ForkRun(forkConfig) else throw new RuntimeException("This plugin can only be run in forked mode")
   }
 
@@ -76,10 +63,8 @@ object SbtNrPlugin extends AutoPlugin {
 
   override def trigger = allRequirements
 
-  override val projectSettings = 
-    Seq(
-      newRelicAgentJar := "",
-      newRelicConfigFile := "",
-      newRelicEnvironment := "development") ++ 
-    inConfig(NewRelic)(defaultNrSettings)
+  override val projectSettings =
+    Seq(newRelicAgentJar := "",
+        newRelicConfigFile := "",
+        newRelicEnvironment := "development")
 }

--- a/play-nr/src/main/scala/sbt/nr/SbtNrPlayPlugin.scala
+++ b/play-nr/src/main/scala/sbt/nr/SbtNrPlayPlugin.scala
@@ -2,20 +2,52 @@ package sbt.nr
 
 import sbt._
 import Keys._
-import play.PlayInternalKeys
+import play.{Play, PlayInternalKeys}
 
 object SbtNrPlayPlugin extends AutoPlugin with PlayInternalKeys {
-  import SbtNrPlugin._
+  import SbtNrPlugin.{autoImport => BaseKeys, verifySettings}
 
-  override def trigger = AllRequirements
+  override def trigger = allRequirements
 
-  override def requires = SbtNrPlugin
+  override def requires = Play && SbtNrPlugin
 
-  lazy val defaultNrSettings: Seq[Def.Setting[_]] = Seq(
-    inTask(run)(Seq(runner <<= SbtNrPlugin.nrRunner)).head,
+  object autoImport {
+    val newRelicPlayRunner = taskKey[BackgroundJobHandle]("Run play dev-mode runner with NewRelic agent")
+  }
 
-    UIKeys.backgroundRunMain in ThisProject := playBackgroundRunTaskBuilder.value((Keys.javaOptions in Runtime).value),
+  import autoImport._
 
-    UIKeys.backgroundRun in ThisProject := playBackgroundRunTaskBuilder.value((Keys.javaOptions in Runtime).value)
-  )
+  def newRelicPlayRunnerTask(newRelicAgentJar:TaskKey[String], newRelicConfigFile:TaskKey[String], newRelicEnvironment:TaskKey[String]):Def.Initialize[Task[BackgroundJobHandle]] = Def.task {
+    val jar = newRelicAgentJar.value
+    val config = newRelicConfigFile.value
+    val env = newRelicEnvironment.value
+    val runner = playBackgroundRunTaskBuilder.value
+
+    println(s" -- jar: $jar")
+    println(s" -- config: $config")
+    println(s" -- env: $env")
+    println(s" -- runner: $runner")
+
+    verifySettings(jar, config)
+
+    val nrJavaOptions: Seq[String] = Seq(
+      s"-javaagent:${jar}",
+      s"-Dnewrelic.config.file=${config}",
+      s"-Dnewrelic.environment=${env}",
+      "-Dnewrelic.enable.java.8")
+
+    println(s" -- options: $nrJavaOptions")
+
+    runner(nrJavaOptions)
+  }
+
+  lazy val defaultNrSettings: Seq[Def.Setting[_]] =
+    Seq(
+      newRelicPlayRunner <<= newRelicPlayRunnerTask(BaseKeys.newRelicAgentJar,BaseKeys.newRelicConfigFile,BaseKeys.newRelicEnvironment)
+    ) ++ inConfig(BaseKeys.NewRelic)(Seq(
+      UIKeys.backgroundRunMain in ThisProject := newRelicPlayRunner.value,
+      UIKeys.backgroundRun in ThisProject := newRelicPlayRunner.value
+    ))
+
+  override val projectSettings = SbtNrPlugin.projectSettings ++ defaultNrSettings
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,9 +2,9 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  def playPlugin = 
-  	Defaults.sbtPluginExtra("com.typesafe.play" % "sbt-plugin" % "2.3.8-96d1003d8219fc35ffdedd8828184ee833d7f758", "0.13", "2.10")
+  def playPlugin =
+  	Defaults.sbtPluginExtra("com.typesafe.play" % "sbt-plugin" % "2.3.8-2de45b3774b6757f4aae980f8b5b152c1d2b73a5", "0.13", "2.10")
 
-  def uiPlugin = 
-  	Defaults.sbtPluginExtra("com.typesafe.sbtrc" % "ui-interface-0-13" % "1.0-43891de56b625f1c0e810348360fee05a22445bf", "0.13", "2.10")
+  def uiPlugin =
+  	Defaults.sbtPluginExtra("com.typesafe.sbtrc" % "ui-interface-0-13" % "1.0-578454dc9da3c43ecd8e842e6d33c0718a5718ba", "0.13", "2.10")
 }


### PR DESCRIPTION
Created a custom runner to run a Play app with the New Relic agent attached.  I did clobber some stuff from the default NR plugin you may want to add back, not sure if/how it's used.  To use the new plugin the only thing you need to do is set:

```
set newRelicAgentJar := "<someplace>/newrelic.jar"
set newRelicConfigFile := "<someplace>/newrelic.yml"
```

The question becomes how/where to set this.  The natural place is in the injected shim file when the project is enabled.

For review by @henrikengstrom, @havocp, and @jsuereth 
